### PR TITLE
Timetable drag to fill/unfill functionality

### DIFF
--- a/best-uvic-scheduler/src/Components/Timetable/Timetable.tsx
+++ b/best-uvic-scheduler/src/Components/Timetable/Timetable.tsx
@@ -86,6 +86,7 @@ const TableDiv = styled.div`
   display: grid;
   grid-template-columns: 150px repeat(5, minmax(0, 1fr));
   border-bottom: 1px solid var(--border);
+  background: #fff;
 `;
 
 const AvDiv = styled.div`
@@ -220,8 +221,12 @@ export function TimetableView(props: TimetableViewProps) {
 
   return (
     <TableDiv
+      draggable="false"
       onMouseDown={() => setMouseDown(true)}
-      onMouseUp={() => setMouseDown(false)}
+      onMouseUp={() => {
+        setMouseDown(false);
+      }}
+      onMouseLeave={() => setMouseDown(false)}
     >
       <div style={{ position: "sticky", top: "0px" }}> </div>
       {weekdays.map((day: string) => {
@@ -242,6 +247,7 @@ export function TimetableView(props: TimetableViewProps) {
 
       {timeslots.map((timeslot, idx) => (
         <TimetableRow
+          draggable="false"
           slotTimes={slotTimes}
           timeslot={timeslot}
           onTimeslots={onTimeslots}

--- a/best-uvic-scheduler/src/Components/Timetable/TimetableRow.tsx
+++ b/best-uvic-scheduler/src/Components/Timetable/TimetableRow.tsx
@@ -32,6 +32,11 @@ const CellDiv = styled.div<{ highlighted: boolean }>`
     ${(props) => props.highlighted && "background-color: var(--primary-500)"}
   }
 
+  &:active {
+    background-color: var(--primary-400);
+    ${(props) => props.highlighted && "background-color: white"}
+  }
+
   ${(props) => props.highlighted && "background-color: var(--primary-400)"}
 `;
 
@@ -63,10 +68,14 @@ export function TimetableRowView(props: TimetableRowViewProps) {
       {timeslot.map((slot: boolean, idx) => {
         return (
           <CellDiv
+            draggable="false"
             key={`${idx}-${slot}`}
-            onClick={() => onTimeslots({ dayIdx: idx, slotIdx: timeslotIdx })}
+            onClick={(e) => {
+              onTimeslots({ dayIdx: idx, slotIdx: timeslotIdx });
+              e.stopPropagation();
+            }}
             highlighted={slot}
-            onMouseEnter={() => {
+            onMouseLeave={() => {
               mouseDown && onTimeslots({ dayIdx: idx, slotIdx: timeslotIdx });
             }}
           >


### PR DESCRIPTION
Provide the ability to drag through the timetable instead of having to click every cell. Fixes #51.

Note for reviewer: definitely worth playing with a bit, this functionality relies on some shaky-ish event handling that could be prone to breaking.